### PR TITLE
Changed configurations to use DatabaseConfigurator stand-in plug-in

### DIFF
--- a/etc/templates/config_with_getenv.py.template
+++ b/etc/templates/config_with_getenv.py.template
@@ -2,20 +2,17 @@ config.production.shortName = "DataRelease"
 config.production.eventBrokerHost = "lsst8.ncsa.uiuc.edu"
 config.production.productionShutdownTopic = "productionShutdown2"
 
-config.database["db1"].name = "dc3bGlobal"
+# note that the database plugin, DatabaseConfigurator, is a placeholder
+# and does no interaction with the database.
+config.database["db1"].name = "Global"
 config.database["db1"].system.authInfo.host = "lsst-db.ncsa.illinois.edu"
 config.database["db1"].system.authInfo.port = 3306
 config.database["db1"].system.runCleanup.daysFirstNotice = 7
 config.database["db1"].system.runCleanup.daysFinalNotice = 1
 
-config.database["db1"].configurationClass = "lsst.ctrl.orca.db.DC3Configurator"
+config.database["db1"].configurationClass = "lsst.ctrl.orca.DatabaseConfigurator"
 config.database["db1"].configuration["production"].globalDbName = "GlobalDB"
 
-config.database["db1"].configuration["production"].dcVersion = "S12_sdss"
-config.database["db1"].configuration["production"].dcDbName = "DC3b_DB"
-config.database["db1"].configuration["production"].minPercDiskSpaceReq = 10
-config.database["db1"].configuration["production"].userRunLife = 2
-config.database["db1"].logger.launch = True
 
 config.workflow["workflow1"].platform.dir.defaultRoot = "$DEFAULT_ROOT"
 

--- a/etc/templates/config_with_setups.py.template
+++ b/etc/templates/config_with_setups.py.template
@@ -2,20 +2,16 @@ config.production.shortName = "DataRelease"
 config.production.eventBrokerHost = "lsst8.ncsa.uiuc.edu"
 config.production.productionShutdownTopic = "productionShutdown2"
 
+# note that the database plugin, DatabaseConfigurator, is a placeholder
+# and does no interaction with the database.
 config.database["db1"].name = "dc3bGlobal"
 config.database["db1"].system.authInfo.host = "lsst-db.ncsa.illinois.edu"
 config.database["db1"].system.authInfo.port = 3306
 config.database["db1"].system.runCleanup.daysFirstNotice = 7
 config.database["db1"].system.runCleanup.daysFinalNotice = 1
 
-config.database["db1"].configurationClass = "lsst.ctrl.orca.db.DC3Configurator"
+config.database["db1"].configurationClass = "lsst.ctrl.orca.DatabaseConfigurator"
 config.database["db1"].configuration["production"].globalDbName = "GlobalDB"
-
-config.database["db1"].configuration["production"].dcVersion = "S12_sdss"
-config.database["db1"].configuration["production"].dcDbName = "DC3b_DB"
-config.database["db1"].configuration["production"].minPercDiskSpaceReq = 10
-config.database["db1"].configuration["production"].userRunLife = 2
-config.database["db1"].logger.launch = True
 
 config.workflow["workflow1"].platform.dir.defaultRoot = "$DEFAULT_ROOT"
 


### PR DESCRIPTION
The DatabaseConfigurator is a base class that is a placeholder for
a "real" implementation of a database plugin.  Since at this time we
don't need to have any interactions with the database (because a
replacement for provenance hasn't been implemented), this information
is unused.  It could be deleted without causing errors in orchestration,
but is being kept here because it will be used in the future.