### PR TITLE
DM-48633 : Support Arbitrary Constraints in Condor Queries

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,5 @@
+Copyright 2008-2025 Association of Universities for Research in Astronomy
+Copyright 2015-2025 The Trustees of Princeton University
+Copyright 2015-2025 University of Washington
+Copyright 2017-2025 The Board of Trustees of the Leland Stanford Junior University, through SLAC National Accelerator Laboratory
+Copyright 2025 University of Illinois Board of Trustees

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+See the COPYRIGHT file for copyright information.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,17 @@
+==========
+lsst-ctrl-execute
+==========
+
+.. image:: https://img.shields.io/pypi/v/lsst-ctrl-execute.svg
+    :target: https://pypi.org/project/lsst-ctrl-execute/
+.. image:: https://codecov.io/gh/lsst/ctrl_execute/branch/main/graph/badge.svg?token=TUaqTDjdIZ
+    :target: https://codecov.io/gh/lsst/ctrl_execute
+
+Workflow Management System execution functions from Rubin Observatory Data Management for the `Legacy Survey of Space and Time (LSST). <https://www.lsst.org>`_.
+
+PyPI: `lsst-ctrl-execute <https://pypi.org/project/lsst-ctrl-execute/>`_
+
+License
+-------
+
+See LICENSE and COPYRIGHT files.

--- a/python/lsst/ctrl/execute/allocator.py
+++ b/python/lsst/ctrl/execute/allocator.py
@@ -78,7 +78,7 @@ class Allocator:
         self.platform = platform
 
         # Look up the user's name and home and scratch directory in the
-        # $HOME/.lsst/condor-info.py file
+        # $HOME/.lsst/condor-info.py file or in the environment.
         user_name = None
         user_home = None
         user_scratch = None
@@ -87,6 +87,10 @@ class Allocator:
                 user_name = condorInfoConfig.platform[name].user.name
                 user_home = condorInfoConfig.platform[name].user.home
                 user_scratch = condorInfoConfig.platform[name].user.scratch
+                if user_name is None and "USER" in os.environ:
+                    user_name = os.environ["USER"]
+                if user_home is None and "HOME" in os.environ:
+                    user_home = os.environ["HOME"]
                 if user_scratch is None and "SCRATCH" in os.environ:
                     user_scratch = os.environ["SCRATCH"]
         if user_name is None:

--- a/python/lsst/ctrl/execute/allocatorParser.py
+++ b/python/lsst/ctrl/execute/allocatorParser.py
@@ -199,6 +199,13 @@ class AllocatorParser:
             help="configure to use dynamic/partitionable slot; legacy option: this is always enabled now",
         )
 
+        parser.add_argument(
+            "--constraint",
+            action="append",
+            dest="constraint",
+            type=str,
+            help="additional contraint predicate to use with htcondor idle job queries",
+        )
         self.args = parser.parse_args()
 
         return self.args

--- a/python/lsst/ctrl/execute/slurmPlugin.py
+++ b/python/lsst/ctrl/execute/slurmPlugin.py
@@ -309,6 +309,12 @@ class SlurmPlugin(Allocator):
         # The constraint determines that the jobs to be returned belong to
         # the current user (Owner) and are Idle vanilla universe jobs.
         full_constraint = f"{owner} && {jstat} && {juniv}"
+        # The constraint may be extended with additional arbitrary predicates
+        # if these have been provided to the allocator.
+        if self.opts.constraint:
+            full_constraint += " && "
+            full_constraint += " && ".join(self.opts.constraint)
+
         _LOG.info("Auto: Query for htcondor jobs.")
         _LOG.debug("full_constraint %s", full_constraint)
         try:


### PR DESCRIPTION
* Adds `--constraint` parameter to AllocateParser so additional arbitrary constraints can be added to HTCondor queries for idle jobs for which to allocate resources. The parameter can be used multiple times to add more constraints. All constraints are `&&` together.
* Adds README, COPYRIGHT, and LICENSE files to the repo.
* Support standard environment variables for condor info config if `USER` or `HOME` not specified in a `condor-info` file.